### PR TITLE
Fix Mixed Content error when Jellyfin is behind a TLS-terminating reverse proxy

### DIFF
--- a/Controllers/JellyEmuController.cs
+++ b/Controllers/JellyEmuController.cs
@@ -79,13 +79,15 @@ namespace JellyEmu.Controllers
             }
 
             var core = ResolveCore(item);
-            var baseUrl = $"{Request.Scheme}://{Request.Host}";
-            var romUrl = $"{baseUrl}/jellyemu/rom/{itemId}";
+            // Use relative URLs so the browser resolves them against the page's origin/scheme.
+            // Request.Scheme is unreliable behind reverse proxies that terminate TLS (would yield http://
+            // while the client loaded the page over https://, triggering Mixed Content blocks).
+            var romUrl = $"/jellyemu/rom/{itemId}";
 
             // Save state URLs — only wired up if a userId was provided
             var hasSaves = !string.IsNullOrEmpty(userId);
-            var saveGetUrl = hasSaves ? $"{baseUrl}/jellyemu/save/{itemId}/{userId}" : "";
-            var savePostUrl = hasSaves ? $"{baseUrl}/jellyemu/save/{itemId}/{userId}" : "";
+            var saveGetUrl = hasSaves ? $"/jellyemu/save/{itemId}/{userId}" : "";
+            var savePostUrl = hasSaves ? $"/jellyemu/save/{itemId}/{userId}" : "";
 
             // Check if a save already exists for this user+item to auto-load it
             var saveExists = hasSaves && System.IO.File.Exists(GetSavePath(userId!, itemId));


### PR DESCRIPTION
## Summary

When Jellyfin is accessed through a reverse proxy that terminates TLS (nginx, Traefik, Caddy, Cloudflare, etc.), the emulator page fails to load the ROM with a browser `Mixed Content` error:

```
Mixed Content: The page at 'https://.../web/...' was loaded over HTTPS, but requested an insecure resource 'http://.../jellyemu/rom/<itemId>'. This request has been blocked; the content must be served over HTTPS.
```

Local (direct `http://host:8096`) access works fine — only remote HTTPS access is broken.

## Cause

In `JellyEmuController.Play`, the ROM and save-state URLs were built as absolute URLs using `Request.Scheme`:

```csharp
var baseUrl = $"{Request.Scheme}://{Request.Host}";
var romUrl = $"{baseUrl}/jellyemu/rom/{itemId}";
```

Behind a TLS-terminating reverse proxy, `Request.Scheme` reflects the scheme between the proxy and Jellyfin (typically `http`), not the scheme the client used to reach the proxy. The browser then sees an `http://` resource embedded in an `https://` page and blocks it.

## Fix

Use relative URLs (`/jellyemu/rom/...`, `/jellyemu/save/...`). The browser resolves them against the parent page's origin and scheme, so they automatically match whatever the client used — HTTPS through the proxy, HTTP for direct local access. No reliance on `X-Forwarded-Proto` or reverse-proxy configuration needed.

## Test plan

- [x] Local direct access (`http://host:8096`) — emulator still loads ROM and save states
- [x] Remote HTTPS access through a TLS-terminating reverse proxy — ROM now loads, no Mixed Content error in console
- [x] Save state upload/download still works in both modes