### PR TITLE
Fix UI injection silently shadowed by escaped dot in fileNamePattern

### DIFF
--- a/JellyEmuInjectorService.cs
+++ b/JellyEmuInjectorService.cs
@@ -23,7 +23,7 @@ namespace JellyEmu.Services
                 var payloadDefinition = new
                 {
                     id = Guid.NewGuid().ToString(),
-                    fileNamePattern = "index\\.html",
+                    fileNamePattern = "index.html",
                     callbackAssembly = GetType().Assembly.FullName,
                     callbackClass = typeof(JellyEmuUIInjector).FullName,
                     callbackMethod = nameof(JellyEmuUIInjector.InjectMods)


### PR DESCRIPTION
Fixes #2.

File Transformation stores registrations in a dictionary keyed by the exact `fileNamePattern` string and only runs one matching bucket per request (exact key match wins over regex match). JellyEmu's `"index\\.html"` (regex-escaped dot) lands in a different dictionary key than the `"index.html"` pattern used by every other plugin that injects into the web client, so JellyEmu's bucket is silently shadowed and `InjectMods` never fires.

Dropping the escape puts JellyEmu's registration in the same bucket as the rest, and the injection runs normally. Verified in-browser: gamepad button renders, clicking it opens the EmulatorJS iframe as expected.