### PR TITLE
Fix threading request on non-trustworthy domains

### DIFF
--- a/Controllers/JellyEmuBaseController.cs
+++ b/Controllers/JellyEmuBaseController.cs
@@ -32,6 +32,37 @@ namespace JellyEmu.Controllers
             }
             return true;
         }
+        /// <summary>
+        /// Gets whether or not the browser should consider the origin trustworthy.
+        /// HTTPS or localhost are trustworthy in most browsers. This is important
+        /// for determining whether or not to send the
+        /// "Cross-Origin-Opener-Policy" header.
+        /// </summary>
+        protected bool IsTrustworthyOrigin()
+        {
+            if (Request.IsHttps) return true;
+
+            var proto = Request.Headers["X-Forwarded-Proto"].ToString();
+            if (proto.Contains("https", StringComparison.OrdinalIgnoreCase)) return true;
+
+            var host = Request.Host.Host;
+            return host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+                || host is "127.0.0.1" or "::1" or "[::1]"
+                || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Applies the cross-origin isolation headers.
+        /// This is skipped on insecure requests to avoid browser security errors.
+        /// </summary>
+        protected void ApplyCrossOriginIsolationHeaders()
+        {
+            if (!IsTrustworthyOrigin()) return;
+
+            Response.Headers["Cross-Origin-Opener-Policy"] = "same-origin";
+            Response.Headers["Cross-Origin-Embedder-Policy"] = "credentialless";
+        }
+
         protected readonly ILibraryManager LibraryManager;
         protected readonly IApplicationPaths AppPaths;
         protected readonly ILogger Logger;

--- a/Controllers/JellyEmuPlayController.cs
+++ b/Controllers/JellyEmuPlayController.cs
@@ -102,8 +102,7 @@ namespace JellyEmu.Controllers
                 cart_url = cartUrl
             });
 
-            Response.Headers["Cross-Origin-Opener-Policy"] = "same-origin";
-            Response.Headers["Cross-Origin-Embedder-Policy"] = "credentialless";
+            ApplyCrossOriginIsolationHeaders();
 
             return Content(html, MediaTypeNames.Text.Html);
         }
@@ -242,8 +241,7 @@ namespace JellyEmu.Controllers
 
             // When opened as a new tab (threaded cores), these headers make the page
             // cross-origin isolated so SharedArrayBuffer is available. Harmless for iframe mode.
-            Response.Headers["Cross-Origin-Opener-Policy"] = "same-origin";
-            Response.Headers["Cross-Origin-Embedder-Policy"] = "credentialless";
+            ApplyCrossOriginIsolationHeaders();
 
             return Content(html, MediaTypeNames.Text.Html);
         }

--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Restart your Jellyfin server. Both plugins must be active at the same time — F
 2. Click **Restart**
 3. Confirm again by clicking **Restart**
 
+### Step 5 — Serve Jellyfin over HTTPS (Optional)
+
+Threaded emulator cores need `SharedArrayBuffer`, which browsers only expose on a cross-origin isolated page. These requires a trustworthy origin, like over HTTPS, or a `localhost` / `127.0.0.1` URL.
+
+Reaching Jellyfin over plain HTTP on a LAN hostname or IP (for example `http://jellyfin:8096`) is *not* a trustworthy origin, so the browser ignores JellyEmu's isolation headers. Games still load and play, but they run single-threaded, resulting in potential performance issues on more demanding systems like N64 or PSP. Put Jellyfin behind an HTTPS reverse proxy to allow threading.
+
 ---
 
 ## ROM Naming & Folder Structure Guide

--- a/README.md
+++ b/README.md
@@ -182,9 +182,7 @@ Restart your Jellyfin server. Both plugins must be active at the same time — F
 
 ### Step 5 — Serve Jellyfin over HTTPS (Optional)
 
-Threaded emulator cores need `SharedArrayBuffer`, which browsers only expose on a cross-origin isolated page. These requires a trustworthy origin, like over HTTPS, or a `localhost` / `127.0.0.1` URL.
-
-Reaching Jellyfin over plain HTTP on a LAN hostname or IP (for example `http://jellyfin:8096`) is *not* a trustworthy origin, so the browser ignores JellyEmu's isolation headers. Games still load and play, but they run single-threaded, resulting in potential performance issues on more demanding systems like N64 or PSP. Put Jellyfin behind an HTTPS reverse proxy to allow threading.
+For demanding systems to run smoothly, like N64 or PSP, JellyEmu will need multi-threading, which is only available over HTTPS. This is optional, however, and only to improve performance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Restart your Jellyfin server. Both plugins must be active at the same time — F
 
 ### Step 5 — Serve Jellyfin over HTTPS (Optional)
 
-For demanding systems to run smoothly, like N64 or PSP, JellyEmu will need multi-threading, which is only available over HTTPS. This is optional, however, and only to improve performance.
+Using Jellyfin over HTTPS is strongly recommended for security if accessing it publicly. It is also required to enable multi-threading for demanding 3D systems like N64 and PSP.
 
 ---
 

--- a/Templates/ejs.html
+++ b/Templates/ejs.html
@@ -2238,7 +2238,16 @@
         {{ end }}
 
         {{ if needs_threads }}
-        window.EJS_threads = true;
+        // Threads need SharedArrayBuffer, which is only available on a cross-origin isolated
+        // page, which requires a trustworthy origin (HTTPS or localhost). Over plain HTTP,
+        // the cross-origin headers are ignored, so we'll let EmulatorJS know to use threads
+        // only when SharedArrayBuffer is available.
+        if (typeof SharedArrayBuffer === 'function') {
+            window.EJS_threads = true;
+        } else {
+            console.warn('[JellyEmu] SharedArrayBuffer unavailable, so running single-threaded. ' +
+                'Use HTTPS to enable threading.');
+        }
         {{ else }}
         // EJS_threads not required for this core
         {{ end }}


### PR DESCRIPTION
I'm hosting Jellyfin on my NAS without HTTPS, which makes EJS break because when JellyEmu requests threading support, it complains that the correct headers aren't there.

The specific error I get is...

> hreads is set to true, but the SharedArrayBuffer function is not exposed. Threads requires 2 headers to be set when sending you html page. See https://stackoverflow.com/a/68630724

While the headers were set, over http, it doesn't get set because....

> Cross-Origin-Opener-Policy header has been ignored, because the URL's origin was untrustworthy.

This change tweaks when those headers are set, making it only happen when behind `https://` or running on a localhost.
