### PR TITLE
Derive version strings from assembly

### DIFF
--- a/Controllers/JellyEmuBaseController.cs
+++ b/Controllers/JellyEmuBaseController.cs
@@ -868,7 +868,7 @@ namespace JellyEmu.Controllers
         protected HttpClient GetRommClient()
         {
             var client = HttpClientFactory.CreateClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+            client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
             var cfg = Plugin.Instance?.Configuration;
             if (cfg == null) return client;
 

--- a/Controllers/JellyEmuDependencyController.cs
+++ b/Controllers/JellyEmuDependencyController.cs
@@ -66,7 +66,7 @@ namespace JellyEmu.Controllers
             try
             {
                 var client = HttpClientFactory.CreateClient("JellyEmuPico8");
-                client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (compatible; JellyEmu/1.0)");
+                client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.BrowserUserAgent);
 
                 using var upstream = await client.GetAsync(
                     JellyEmuPico8Manager.RuntimeUrl,
@@ -117,7 +117,7 @@ namespace JellyEmu.Controllers
             try
             {
                 var client = HttpClientFactory.CreateClient("JellyEmuThreeJs");
-                client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (compatible; JellyEmu/1.0)");
+                client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.BrowserUserAgent);
 
                 using var upstream = await client.GetAsync(
                     JellyEmuThreeJsManager.RuntimeUrl,

--- a/Controllers/JellyEmuPlayController.cs
+++ b/Controllers/JellyEmuPlayController.cs
@@ -269,7 +269,7 @@ namespace JellyEmu.Controllers
                 scale = effectivePrefs.Scale,
                 volume = effectivePrefs.Volume ?? "1",
                 mute = effectivePrefs.Mute ?? "0",
-                version = GetType().Assembly.GetName().Version?.ToString() ?? "0.8.8"
+                version = JellyEmuVersion.Value
             });
 
             // When opened as a new tab (threaded cores), these headers make the page

--- a/Controllers/JellyEmuRetroAchievementsController.cs
+++ b/Controllers/JellyEmuRetroAchievementsController.cs
@@ -159,7 +159,7 @@ namespace JellyEmu.Controllers
             {
                 var url = $"https://retroachievements.org/API/API_GetGameInfoAndUserProgress.php?z={prefs.RaUsername}&y={prefs.RaApiKey}&g={raGameId}&u={prefs.RaUsername}&a=1";
                 var client = HttpClientFactory.CreateClient();
-                client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+                client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
 
                 var response = await client.GetAsync(url).ConfigureAwait(false);
                 if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
@@ -220,7 +220,7 @@ namespace JellyEmu.Controllers
             {
                 var url = $"https://retroachievements.org/dorequest.php?r=gameid&m={md5}";
                 var client = HttpClientFactory.CreateClient();
-                client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+                client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
 
                 var response = await client.GetAsync(url).ConfigureAwait(false);
 

--- a/Controllers/JellyEmuRommController.cs
+++ b/Controllers/JellyEmuRommController.cs
@@ -38,7 +38,7 @@ namespace JellyEmu.Controllers
                 return Ok(new { reachable = false, reason = "No Romm URL configured" });
 
             var client = HttpClientFactory.CreateClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+            client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
             client.Timeout = TimeSpan.FromSeconds(8);
 
             foreach (var probe in new[] { "/api/heartbeat", "/api/", "/" })

--- a/JellyEmuUIInjector.cs
+++ b/JellyEmuUIInjector.cs
@@ -29,7 +29,7 @@ namespace JellyEmu.Services
 
                 bool vantageEnabled = Plugin.Instance?.Configuration?.VantageEnabled ?? true;
                 string vantageStr = vantageEnabled ? "true" : "false";
-                string versionStr = typeof(JellyEmuUIInjector).Assembly.GetName().Version?.ToString() ?? "0.8.8";
+                string versionStr = JellyEmuVersion.Value;
 
                 string injection = $$"""
                 <link rel="stylesheet" href="/jellyemu/assets/injection/bundle.css?v={{versionStr}}" data-jellyemu-mods="1">

--- a/JellyEmuVersion.cs
+++ b/JellyEmuVersion.cs
@@ -1,0 +1,25 @@
+namespace JellyEmu
+{
+    /// <summary>
+    /// Single source of truth for the plugin's version and User-Agent strings,
+    /// derived from the assembly version so they never go stale.
+    /// </summary>
+    public static class JellyEmuVersion
+    {
+        /// <summary>
+        /// The plugin version, e.g. "0.9.0.0".
+        /// </summary>
+        public static string Value { get; } =
+            typeof(JellyEmuVersion).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+
+        /// <summary>
+        /// The plain User-Agent product token, e.g. "JellyEmu/0.9.0.0".
+        /// </summary>
+        public static string UserAgent { get; } = $"JellyEmu/{Value}";
+
+        /// <summary>
+        /// A browser-compatible User-Agent for services that reject bare product tokens.
+        /// </summary>
+        public static string BrowserUserAgent { get; } = $"Mozilla/5.0 (compatible; JellyEmu/{Value})";
+    }
+}

--- a/PluginServiceRegistrar.cs
+++ b/PluginServiceRegistrar.cs
@@ -12,14 +12,14 @@ namespace JellyEmu
             serviceCollection.AddHttpClient("JellyEmuEjs", client =>
             {
                 client.DefaultRequestHeaders.UserAgent.ParseAdd(
-                    "JellyEmu/1.0 (Jellyfin plugin; +https://github.com/Jellyfin-PG/JellyEmu)");
+                    $"{JellyEmuVersion.UserAgent} (Jellyfin plugin; +https://github.com/Jellyfin-PG/JellyEmu)");
                 client.Timeout = TimeSpan.FromMinutes(10);
             });
 
             serviceCollection.AddHttpClient("JellyEmuPico8", client =>
             {
                 client.DefaultRequestHeaders.UserAgent.ParseAdd(
-                    "Mozilla/5.0 (compatible; JellyEmu/1.0)");
+                    JellyEmuVersion.BrowserUserAgent);
                 client.Timeout = TimeSpan.FromMinutes(5);
             });
 

--- a/Providers/GogProvider.cs
+++ b/Providers/GogProvider.cs
@@ -28,7 +28,7 @@ namespace JellyEmu.Providers
         protected HttpClient GetHttpClient()
         {
             var client = HttpClientFactory.CreateClient();
-            client.DefaultRequestHeaders.Add("User-Agent", $"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 {JellyEmuVersion.UserAgent}");
+            client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.BrowserUserAgent);
             return client;
         }
 

--- a/Providers/GogProvider.cs
+++ b/Providers/GogProvider.cs
@@ -28,7 +28,7 @@ namespace JellyEmu.Providers
         protected HttpClient GetHttpClient()
         {
             var client = HttpClientFactory.CreateClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 JellyEmu/1.0");
+            client.DefaultRequestHeaders.Add("User-Agent", $"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 {JellyEmuVersion.UserAgent}");
             return client;
         }
 

--- a/Providers/HasheousProvider.cs
+++ b/Providers/HasheousProvider.cs
@@ -57,7 +57,7 @@ namespace JellyEmu.Providers
                         : $"https://hasheous.org/api/v1/Lookup/ByHash/md5/{md5}";
 
                     var client = _httpClientFactory.CreateClient();
-                    client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+                    client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
 
                     var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
                     if (response.IsSuccessStatusCode)
@@ -126,7 +126,7 @@ namespace JellyEmu.Providers
                     ? $"https://hasheous.org/api/v1/Lookup/ById/{hasheousId}"
                     : $"https://hasheous.org/api/v1/Lookup/ByHash/md5/{md5}";
                 var client = _httpClientFactory.CreateClient();
-                client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+                client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
                 
                 var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -323,7 +323,7 @@ namespace JellyEmu.Providers
                     : $"https://hasheous.org/api/v1/Lookup/ByHash/md5/{md5}";
 
                 var client = _httpClientFactory.CreateClient();
-                client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+                client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
                 
                 var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)

--- a/Providers/RawgProvider.cs
+++ b/Providers/RawgProvider.cs
@@ -25,7 +25,7 @@ namespace JellyEmu.Providers
         protected HttpClient GetHttpClient()
         {
             var client = HttpClientFactory.CreateClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+            client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
             return client;
         }
 

--- a/Providers/RommProvider.cs
+++ b/Providers/RommProvider.cs
@@ -28,7 +28,7 @@ namespace JellyEmu.Providers
         protected HttpClient GetHttpClient()
         {
             var client = HttpClientFactory.CreateClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "JellyEmu/1.0");
+            client.DefaultRequestHeaders.Add("User-Agent", JellyEmuVersion.UserAgent);
             if (!string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password))
             {
                 var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));

--- a/Providers/TheGamesDbProvider.cs
+++ b/Providers/TheGamesDbProvider.cs
@@ -30,7 +30,7 @@ namespace JellyEmu.Providers
             var client = HttpClientFactory.CreateClient();
             if (!client.DefaultRequestHeaders.Contains("User-Agent"))
             {
-                client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "JellyEmu/1.0");
+                client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", JellyEmuVersion.UserAgent);
             }
             return client;
         }

--- a/Providers/wikipediaProvider.cs
+++ b/Providers/wikipediaProvider.cs
@@ -24,7 +24,7 @@ namespace JellyEmu.Providers
             var client = HttpClientFactory.CreateClient();
             if (!client.DefaultRequestHeaders.Contains("User-Agent"))
             {
-                client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "JellyEmu/1.0 (https://github.com/grimmdev/JellyEmu)");
+                client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", $"{JellyEmuVersion.UserAgent} (https://github.com/Jellyfin-PG/JellyEmu)");
             }
             return client;
         }

--- a/Services/JellyEmuPico8Manager.cs
+++ b/Services/JellyEmuPico8Manager.cs
@@ -90,7 +90,7 @@ namespace JellyEmu.Services
 
                 var client = _httpClientFactory.CreateClient("JellyEmuPico8");
                 client.DefaultRequestHeaders.Add("User-Agent",
-                    "Mozilla/5.0 (compatible; JellyEmu/1.0)");
+                    JellyEmuVersion.BrowserUserAgent);
 
                 _logger.LogInformation("[JellyEmu] Fetching PICO-8 runtime from {Url}", RuntimeUrl);
 

--- a/Services/JellyEmuThreeJsManager.cs
+++ b/Services/JellyEmuThreeJsManager.cs
@@ -85,7 +85,7 @@ namespace JellyEmu.Services
 
                 var client = _httpClientFactory.CreateClient("JellyEmuThreeJs");
                 client.DefaultRequestHeaders.Add("User-Agent",
-                    "Mozilla/5.0 (compatible; JellyEmu/1.0)");
+                    JellyEmuVersion.BrowserUserAgent);
 
                 _logger.LogInformation("[JellyEmu] Fetching Three.js runtime from {Url}", RuntimeUrl);
 


### PR DESCRIPTION
Replaces the hardcoded version numbers with a `JellyEmuVersion` helper that grabs the version number from the assembly.