### PR TITLE
thegamesdb: Fix TheGamesDB.net Key URL

### DIFF
--- a/Configuration/tabs/SettingsTab.html
+++ b/Configuration/tabs/SettingsTab.html
@@ -101,8 +101,8 @@
                     </div>
                     <p class="je-provider-subcard-desc">
                         Community database for retro game metadata, front/back box art, and fanart.
-                        Get your free API key at <a href="https://thegamesdb.net/user/api/" target="_blank"
-                            style="color: #00a4dc; text-decoration: none;">thegamesdb.net/user/api</a>.
+                        Get your free API key at <a href="https://thegamesdb.net/profile.php" target="_blank"
+                            style="color: #00a4dc; text-decoration: none;">thegamesdb.net/profile.php</a>.
                     </p>
                     <div class="inputContainer">
                         <label class="inputLabel inputLabelUnfocused" for="theGamesDbApiKey">TheGamesDB API Key</label>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -68,7 +68,7 @@ namespace JellyEmu
         public string SteamGridDbApiKey { get; set; } = string.Empty;
 
         /// <summary>
-        /// TheGamesDB API Key. Get yours at https://thegamesdb.net/user/api/
+        /// TheGamesDB API Key. Get yours at https://thegamesdb.net/profile.php
         /// </summary>
         public string TheGamesDbApiKey { get; set; } = string.Empty;
 


### PR DESCRIPTION
This updates the TheGamesDB URL from `https://thegamesdb.net/user/api/` to https://thegamesdb.net/profile.php .
